### PR TITLE
Switch over to using anyio completely instead of relying on Trio and Asyncio in a mixture.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -18,7 +18,6 @@ trio = "*"
 httpx = {extras = ["http2"], version = "*"}
 sniffio = "*"
 tenacity = "*"
-trio-util = "*"
 cchardet = "*"
 brotlipy = "*"
 # trio-parallel = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -27,6 +27,7 @@ brotlipy = "*"
 trio-asyncio = {editable = true, git = "https://github.com/python-trio/trio-asyncio.git"}
 discord-py-slash-command = "*"
 attrs = "*"
+anyio = {editable = true, git = "https://github.com/agronholm/anyio.git"}
 
 [requires]
 python_version = "3.9"

--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ verify_ssl = true
 
 [dev-packages]
 ipython = "*"
-trio-typing = "*"
+# trio-typing = "*"
 mypy = "*"
 black = {extras = ["d"], version = "*"}
 "discord.py-stubs" = "*"
@@ -14,7 +14,7 @@ black = {extras = ["d"], version = "*"}
 peewee = "*"
 discord-py = {extras = ["voice"], version = "*"}
 loguru = "*"
-trio = "*"
+# trio = "*"
 httpx = {extras = ["http2"], version = "*"}
 sniffio = "*"
 tenacity = "*"
@@ -23,10 +23,11 @@ brotlipy = "*"
 # trio-parallel = "*"
 # trimeter = {editable = true, git = "https://github.com/python-trio/trimeter.git"}
 # perf-timer = "*"
-trio-asyncio = {editable = true, git = "https://github.com/python-trio/trio-asyncio.git"}
+# trio-asyncio = {editable = true, git = "https://github.com/python-trio/trio-asyncio.git"}
 discord-py-slash-command = "*"
 attrs = "*"
 anyio = {editable = true, git = "https://github.com/agronholm/anyio.git"}
+uvloop = "*"
 
 [requires]
 python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "68d09bb710e08782d6c5904486983d383ed22863032e7aeefce12dd359f90ada"
+            "sha256": "62ba09e76991f0daa00f491454aea5d1878ab7a477455118a8c0bf8d55dca5ce"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -60,12 +60,9 @@
             "version": "==3.7.4.post0"
         },
         "anyio": {
-            "hashes": [
-                "sha256:8a56e08623dc55955a06719d4ad62de6009bb3f1dd04936e60b2104dd58da484",
-                "sha256:c286818ccd5dcbd5d385b223f16a055393474527b1d5650da489828a9887d559"
-            ],
-            "index": "pypi",
-            "version": "==2.1.0"
+            "editable": true,
+            "git": "https://github.com/agronholm/anyio.git",
+            "ref": "9e58d1af8a2cc9f42406dc9000d83f338a863d34"
         },
         "async-generator": {
             "hashes": [
@@ -280,11 +277,11 @@
                 "http2"
             ],
             "hashes": [
-                "sha256:4f7ab2fef7f929c5531abd4f413b41ce2c820e3202f2eeee498f2d92b6849f8d",
-                "sha256:fe19522f7b0861a1f6ac83306360bb5b7fb1ed64633a1a04a33f04102a1bea60"
+                "sha256:cc2a55188e4b25272d2bcd46379d300f632045de4377682aa98a8a6069d55967",
+                "sha256:d379653bd457e8257eb0df99cb94557e4aac441b7ba948e333be969298cac272"
             ],
             "index": "pypi",
-            "version": "==0.17.0"
+            "version": "==0.17.1"
         },
         "hyperframe": {
             "hashes": [
@@ -298,7 +295,6 @@
                 "sha256:5205d03e7bcbb919cc9c19885f9920d622ca52448306f2377daede5cf3faac16",
                 "sha256:c5b02147e01ea9920e6b0a3f1f7bb833612d507592c837a6c49552768f4054e1"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==3.1"
         },
         "loguru": {
@@ -362,10 +358,10 @@
         },
         "peewee": {
             "hashes": [
-                "sha256:9f4ad3f8e5e7719689cdd38ea13aa4e979e3805f8f675ea9005c9a6534f199ea"
+                "sha256:9e356b327c2eaec6dd42ecea6f4ddded025793dba906a3d065a0452e726c51a2"
             ],
             "index": "pypi",
-            "version": "==3.14.2"
+            "version": "==3.14.4"
         },
         "pycparser": {
             "hashes": [
@@ -655,7 +651,6 @@
                 "sha256:5205d03e7bcbb919cc9c19885f9920d622ca52448306f2377daede5cf3faac16",
                 "sha256:c5b02147e01ea9920e6b0a3f1f7bb833612d507592c837a6c49552768f4054e1"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==3.1"
         },
         "ipython": {
@@ -799,11 +794,11 @@
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:0fa02fa80363844a4ab4b8d6891f62dd0645ba672723130423ca4037b80c1974",
-                "sha256:62c811e46bd09130fb11ab759012a4ae385ce4fb2073442d1898867a824183bd"
+                "sha256:4cea7d09e46723885cb8bc54678175453e5071e9449821dce6f017b1d1fbfc1a",
+                "sha256:9397a7162cf45449147ad6042fa37983a081b8a73363a5253dd4072666333137"
             ],
             "markers": "python_full_version >= '3.6.1'",
-            "version": "==3.0.16"
+            "version": "==3.0.17"
         },
         "ptyprocess": {
             "hashes": [
@@ -822,49 +817,49 @@
         },
         "regex": {
             "hashes": [
-                "sha256:02951b7dacb123d8ea6da44fe45ddd084aa6777d4b2454fa0da61d569c6fa538",
-                "sha256:0d08e71e70c0237883d0bef12cad5145b84c3705e9c6a588b2a9c7080e5af2a4",
-                "sha256:1862a9d9194fae76a7aaf0150d5f2a8ec1da89e8b55890b1786b8f88a0f619dc",
-                "sha256:1ab79fcb02b930de09c76d024d279686ec5d532eb814fd0ed1e0051eb8bd2daa",
-                "sha256:1fa7ee9c2a0e30405e21031d07d7ba8617bc590d391adfc2b7f1e8b99f46f444",
-                "sha256:262c6825b309e6485ec2493ffc7e62a13cf13fb2a8b6d212f72bd53ad34118f1",
-                "sha256:2a11a3e90bd9901d70a5b31d7dd85114755a581a5da3fc996abfefa48aee78af",
-                "sha256:2c99e97d388cd0a8d30f7c514d67887d8021541b875baf09791a3baad48bb4f8",
-                "sha256:3128e30d83f2e70b0bed9b2a34e92707d0877e460b402faca908c6667092ada9",
-                "sha256:38c8fd190db64f513fe4e1baa59fed086ae71fa45083b6936b52d34df8f86a88",
-                "sha256:3bddc701bdd1efa0d5264d2649588cbfda549b2899dc8d50417e47a82e1387ba",
-                "sha256:4902e6aa086cbb224241adbc2f06235927d5cdacffb2425c73e6570e8d862364",
-                "sha256:49cae022fa13f09be91b2c880e58e14b6da5d10639ed45ca69b85faf039f7a4e",
-                "sha256:56e01daca75eae420bce184edd8bb341c8eebb19dd3bce7266332258f9fb9dd7",
-                "sha256:5862975b45d451b6db51c2e654990c1820523a5b07100fc6903e9c86575202a0",
-                "sha256:6a8ce43923c518c24a2579fda49f093f1397dad5d18346211e46f134fc624e31",
-                "sha256:6c54ce4b5d61a7129bad5c5dc279e222afd00e721bf92f9ef09e4fae28755683",
-                "sha256:6e4b08c6f8daca7d8f07c8d24e4331ae7953333dbd09c648ed6ebd24db5a10ee",
-                "sha256:717881211f46de3ab130b58ec0908267961fadc06e44f974466d1887f865bd5b",
-                "sha256:749078d1eb89484db5f34b4012092ad14b327944ee7f1c4f74d6279a6e4d1884",
-                "sha256:7913bd25f4ab274ba37bc97ad0e21c31004224ccb02765ad984eef43e04acc6c",
-                "sha256:7a25fcbeae08f96a754b45bdc050e1fb94b95cab046bf56b016c25e9ab127b3e",
-                "sha256:83d6b356e116ca119db8e7c6fc2983289d87b27b3fac238cfe5dca529d884562",
-                "sha256:8b882a78c320478b12ff024e81dc7d43c1462aa4a3341c754ee65d857a521f85",
-                "sha256:8f6a2229e8ad946e36815f2a03386bb8353d4bde368fdf8ca5f0cb97264d3b5c",
-                "sha256:9801c4c1d9ae6a70aeb2128e5b4b68c45d4f0af0d1535500884d644fa9b768c6",
-                "sha256:a15f64ae3a027b64496a71ab1f722355e570c3fac5ba2801cafce846bf5af01d",
-                "sha256:a3d748383762e56337c39ab35c6ed4deb88df5326f97a38946ddd19028ecce6b",
-                "sha256:a63f1a07932c9686d2d416fb295ec2c01ab246e89b4d58e5fa468089cab44b70",
-                "sha256:b2b1a5ddae3677d89b686e5c625fc5547c6e492bd755b520de5332773a8af06b",
-                "sha256:b2f4007bff007c96a173e24dcda236e5e83bde4358a557f9ccf5e014439eae4b",
-                "sha256:baf378ba6151f6e272824b86a774326f692bc2ef4cc5ce8d5bc76e38c813a55f",
-                "sha256:bafb01b4688833e099d79e7efd23f99172f501a15c44f21ea2118681473fdba0",
-                "sha256:bba349276b126947b014e50ab3316c027cac1495992f10e5682dc677b3dfa0c5",
-                "sha256:c084582d4215593f2f1d28b65d2a2f3aceff8342aa85afd7be23a9cad74a0de5",
-                "sha256:d1ebb090a426db66dd80df8ca85adc4abfcbad8a7c2e9a5ec7513ede522e0a8f",
-                "sha256:d2d8ce12b7c12c87e41123997ebaf1a5767a5be3ec545f64675388970f415e2e",
-                "sha256:e32f5f3d1b1c663af7f9c4c1e72e6ffe9a78c03a31e149259f531e0fed826512",
-                "sha256:e3faaf10a0d1e8e23a9b51d1900b72e1635c2d5b0e1bea1c18022486a8e2e52d",
-                "sha256:f7d29a6fc4760300f86ae329e3b6ca28ea9c20823df123a2ea8693e967b29917",
-                "sha256:f8f295db00ef5f8bae530fc39af0b40486ca6068733fb860b42115052206466f"
+                "sha256:07ef35301b4484bce843831e7039a84e19d8d33b3f8b2f9aab86c376813d0139",
+                "sha256:13f50969028e81765ed2a1c5fcfdc246c245cf8d47986d5172e82ab1a0c42ee5",
+                "sha256:14de88eda0976020528efc92d0a1f8830e2fb0de2ae6005a6fc4e062553031fa",
+                "sha256:159fac1a4731409c830d32913f13f68346d6b8e39650ed5d704a9ce2f9ef9cb3",
+                "sha256:18e25e0afe1cf0f62781a150c1454b2113785401ba285c745acf10c8ca8917df",
+                "sha256:201e2619a77b21a7780580ab7b5ce43835e242d3e20fef50f66a8df0542e437f",
+                "sha256:360a01b5fa2ad35b3113ae0c07fb544ad180603fa3b1f074f52d98c1096fa15e",
+                "sha256:39c44532d0e4f1639a89e52355b949573e1e2c5116106a395642cbbae0ff9bcd",
+                "sha256:3d9356add82cff75413bec360c1eca3e58db4a9f5dafa1f19650958a81e3249d",
+                "sha256:3d9a7e215e02bd7646a91fb8bcba30bc55fd42a719d6b35cf80e5bae31d9134e",
+                "sha256:4651f839dbde0816798e698626af6a2469eee6d9964824bb5386091255a1694f",
+                "sha256:486a5f8e11e1f5bbfcad87f7c7745eb14796642323e7e1829a331f87a713daaa",
+                "sha256:4b8a1fb724904139149a43e172850f35aa6ea97fb0545244dc0b805e0154ed68",
+                "sha256:4c0788010a93ace8a174d73e7c6c9d3e6e3b7ad99a453c8ee8c975ddd9965643",
+                "sha256:4c2e364491406b7888c2ad4428245fc56c327e34a5dfe58fd40df272b3c3dab3",
+                "sha256:575a832e09d237ae5fedb825a7a5bc6a116090dd57d6417d4f3b75121c73e3be",
+                "sha256:5770a51180d85ea468234bc7987f5597803a4c3d7463e7323322fe4a1b181578",
+                "sha256:633497504e2a485a70a3268d4fc403fe3063a50a50eed1039083e9471ad0101c",
+                "sha256:63f3ca8451e5ff7133ffbec9eda641aeab2001be1a01878990f6c87e3c44b9d5",
+                "sha256:709f65bb2fa9825f09892617d01246002097f8f9b6dde8d1bb4083cf554701ba",
+                "sha256:808404898e9a765e4058bf3d7607d0629000e0a14a6782ccbb089296b76fa8fe",
+                "sha256:882f53afe31ef0425b405a3f601c0009b44206ea7f55ee1c606aad3cc213a52c",
+                "sha256:8bd4f91f3fb1c9b1380d6894bd5b4a519409135bec14c0c80151e58394a4e88a",
+                "sha256:8e65e3e4c6feadf6770e2ad89ad3deb524bcb03d8dc679f381d0568c024e0deb",
+                "sha256:976a54d44fd043d958a69b18705a910a8376196c6b6ee5f2596ffc11bff4420d",
+                "sha256:a0d04128e005142260de3733591ddf476e4902c0c23c1af237d9acf3c96e1b38",
+                "sha256:a0df9a0ad2aad49ea3c7f65edd2ffb3d5c59589b85992a6006354f6fb109bb18",
+                "sha256:a2ee026f4156789df8644d23ef423e6194fad0bc53575534101bb1de5d67e8ce",
+                "sha256:a59a2ee329b3de764b21495d78c92ab00b4ea79acef0f7ae8c1067f773570afa",
+                "sha256:b97ec5d299c10d96617cc851b2e0f81ba5d9d6248413cd374ef7f3a8871ee4a6",
+                "sha256:b98bc9db003f1079caf07b610377ed1ac2e2c11acc2bea4892e28cc5b509d8d5",
+                "sha256:b9d8d286c53fe0cbc6d20bf3d583cabcd1499d89034524e3b94c93a5ab85ca90",
+                "sha256:bcd945175c29a672f13fce13a11893556cd440e37c1b643d6eeab1988c8b209c",
+                "sha256:c66221e947d7207457f8b6f42b12f613b09efa9669f65a587a2a71f6a0e4d106",
+                "sha256:c782da0e45aff131f0bed6e66fbcfa589ff2862fc719b83a88640daa01a5aff7",
+                "sha256:cb4ee827857a5ad9b8ae34d3c8cc51151cb4a3fe082c12ec20ec73e63cc7c6f0",
+                "sha256:d47d359545b0ccad29d572ecd52c9da945de7cd6cf9c0cfcb0269f76d3555689",
+                "sha256:dc9963aacb7da5177e40874585d7407c0f93fb9d7518ec58b86e562f633f36cd",
+                "sha256:ea2f41445852c660ba7c3ebf7d70b3779b20d9ca8ba54485a17740db49f46932",
+                "sha256:f5d0c921c99297354cecc5a416ee4280bd3f20fd81b9fb671ca6be71499c3fdf",
+                "sha256:f85d6f41e34f6a2d1607e312820971872944f1661a73d33e1e82d35ea3305e14"
             ],
-            "version": "==2020.11.13"
+            "version": "==2021.3.17"
         },
         "sniffio": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2175ee24a76485be323d2cf4e3c6843b42273b61a0d660a94c1325d8731ff321"
+            "sha256": "68d09bb710e08782d6c5904486983d383ed22863032e7aeefce12dd359f90ada"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -58,6 +58,14 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==3.7.4.post0"
+        },
+        "anyio": {
+            "hashes": [
+                "sha256:8a56e08623dc55955a06719d4ad62de6009bb3f1dd04936e60b2104dd58da484",
+                "sha256:c286818ccd5dcbd5d385b223f16a055393474527b1d5650da489828a9887d559"
+            ],
+            "index": "pypi",
+            "version": "==2.1.0"
         },
         "async-generator": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "62ba09e76991f0daa00f491454aea5d1878ab7a477455118a8c0bf8d55dca5ce"
+            "sha256": "913f8cfb2f826447de73852c0eb735bc27b0ca58e7e3ae436d8412274d2b216d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -448,14 +448,6 @@
             "git": "https://github.com/python-trio/trio-asyncio.git",
             "ref": "308dd765dbf9d572f45f884492aecc9e1ebf6054"
         },
-        "trio-util": {
-            "hashes": [
-                "sha256:a4b1db87191e56dfce3e6bc244d3232fa9f28ed4ec829c8ba22304f81400fe89",
-                "sha256:e34aa629cef02f8a653ed4ae2ecbda0acb5000bd9d6ff48e95b64d8ca7b2c9a2"
-            ],
-            "index": "pypi",
-            "version": "==0.4.0"
-        },
         "typing-extensions": {
             "hashes": [
                 "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918",
@@ -638,13 +630,21 @@
             ],
             "version": "==4.4.2"
         },
+        "discord.py": {
+            "hashes": [
+                "sha256:3df148daf6fbcc7ab5b11042368a3cd5f7b730b62f09fb5d3cbceff59bcfbb12",
+                "sha256:ba8be99ff1b8c616f7b6dcb700460d0222b29d4c11048e74366954c465fdd05f"
+            ],
+            "markers": "python_full_version >= '3.5.3'",
+            "version": "==1.6.0"
+        },
         "discord.py-stubs": {
             "hashes": [
-                "sha256:42e527eb7db7c147a753ab4bd22f30fc561962d78937edfd53e94731584054ae",
-                "sha256:d35ec693369b3ee2d7918f48d0b15c55c1a55de82c0d6a15f6b90da222109718"
+                "sha256:1c33afbbce2fbdd95781a87e7872e554e1c67b0c9b7af4c966c52d24dbbacf68",
+                "sha256:c334ba6790f6b5873ccde22cf433b9f38161bd0e882115f2f1fadcf03ca22fa1"
             ],
             "index": "pypi",
-            "version": "==1.6.0.2"
+            "version": "==1.6.2"
         },
         "idna": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "913f8cfb2f826447de73852c0eb735bc27b0ca58e7e3ae436d8412274d2b216d"
+            "sha256": "10c4a9321a6e5955d30c705ad98d6293dd05462348e611116f4eca1ac42bb8b1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -63,14 +63,6 @@
             "editable": true,
             "git": "https://github.com/agronholm/anyio.git",
             "ref": "9e58d1af8a2cc9f42406dc9000d83f338a863d34"
-        },
-        "async-generator": {
-            "hashes": [
-                "sha256:01c7bf666359b4967d2cda0000cc2e4af16a0ae098cbffcb8472fb9e8ad6585b",
-                "sha256:6ebb3d106c12920aaae42ccb6f787ef5eefdcdd166ea3d628fa8476abe712144"
-            ],
-            "markers": "python_version >= '3.5'",
-            "version": "==1.10"
         },
         "async-timeout": {
             "hashes": [
@@ -348,14 +340,6 @@
             "markers": "python_version >= '3.6'",
             "version": "==5.1.0"
         },
-        "outcome": {
-            "hashes": [
-                "sha256:c7dd9375cfd3c12db9801d080a3b63d4b0a261aa996c4c13152380587288d958",
-                "sha256:e862f01d4e626e63e8f92c38d1f8d5546d3f9cce989263c521b2e7990d186967"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==1.1.0"
-        },
         "peewee": {
             "hashes": [
                 "sha256:9e356b327c2eaec6dd42ecea6f4ddded025793dba906a3d065a0452e726c51a2"
@@ -409,7 +393,7 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.15.0"
         },
         "sniffio": {
@@ -420,13 +404,6 @@
             "index": "pypi",
             "version": "==1.2.0"
         },
-        "sortedcontainers": {
-            "hashes": [
-                "sha256:37257a32add0a3ee490bb170b599e93095eed89a55da91fa9f48753ea12fd73f",
-                "sha256:59cc937650cf60d677c16775597c89a960658a09cf7c1a668f86e1e4464b10a1"
-            ],
-            "version": "==2.3.0"
-        },
         "tenacity": {
             "hashes": [
                 "sha256:5bd16ef5d3b985647fe28dfa6f695d343aa26479a04e8792b9d3c8f49e361ae1",
@@ -435,19 +412,6 @@
             "index": "pypi",
             "version": "==7.0.0"
         },
-        "trio": {
-            "hashes": [
-                "sha256:87a66ae61f27fe500c9024926a9ba482c07e1e0f56380b70a264d19c435ba076",
-                "sha256:a42af0634ba729cbfe8578be058750c6471dac19fbc7167ec6a3ca3f966fb424"
-            ],
-            "index": "pypi",
-            "version": "==0.18.0"
-        },
-        "trio-asyncio": {
-            "editable": true,
-            "git": "https://github.com/python-trio/trio-asyncio.git",
-            "ref": "308dd765dbf9d572f45f884492aecc9e1ebf6054"
-        },
         "typing-extensions": {
             "hashes": [
                 "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918",
@@ -455,6 +419,22 @@
                 "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
             ],
             "version": "==3.7.4.3"
+        },
+        "uvloop": {
+            "hashes": [
+                "sha256:114543c84e95df1b4ff546e6e3a27521580466a30127f12172a3278172ad68bc",
+                "sha256:19fa1d56c91341318ac5d417e7b61c56e9a41183946cc70c411341173de02c69",
+                "sha256:2bb0624a8a70834e54dde8feed62ed63b50bad7a1265c40d6403a2ac447bce01",
+                "sha256:42eda9f525a208fbc4f7cecd00fa15c57cc57646c76632b3ba2fe005004f051d",
+                "sha256:44cac8575bf168601424302045234d74e3561fbdbac39b2b54cc1d1d00b70760",
+                "sha256:6de130d0cb78985a5d080e323b86c5ecaf3af82f4890492c05981707852f983c",
+                "sha256:7ae39b11a5f4cec1432d706c21ecc62f9e04d116883178b09671aa29c46f7a47",
+                "sha256:90e56f17755e41b425ad19a08c41dc358fa7bf1226c0f8e54d4d02d556f7af7c",
+                "sha256:b45218c99795803fb8bdbc9435ff7f54e3a591b44cd4c121b02fa83affb61c7c",
+                "sha256:e5e5f855c9bf483ee6cd1eb9a179b740de80cb0ae2988e3fa22309b78e2ea0e7"
+            ],
+            "index": "pypi",
+            "version": "==0.15.2"
         },
         "yarl": {
             "hashes": [
@@ -565,14 +545,6 @@
             ],
             "markers": "sys_platform == 'darwin'",
             "version": "==0.1.2"
-        },
-        "async-generator": {
-            "hashes": [
-                "sha256:01c7bf666359b4967d2cda0000cc2e4af16a0ae098cbffcb8472fb9e8ad6585b",
-                "sha256:6ebb3d106c12920aaae42ccb6f787ef5eefdcdd166ea3d628fa8476abe712144"
-            ],
-            "markers": "python_version >= '3.5'",
-            "version": "==1.10"
         },
         "async-timeout": {
             "hashes": [
@@ -754,14 +726,6 @@
             ],
             "version": "==0.4.3"
         },
-        "outcome": {
-            "hashes": [
-                "sha256:c7dd9375cfd3c12db9801d080a3b63d4b0a261aa996c4c13152380587288d958",
-                "sha256:e862f01d4e626e63e8f92c38d1f8d5546d3f9cce989263c521b2e7990d186967"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==1.1.0"
-        },
         "parso": {
             "hashes": [
                 "sha256:15b00182f472319383252c18d5913b69269590616c947747bc50bf4ac768f410",
@@ -861,27 +825,12 @@
             ],
             "version": "==2021.3.17"
         },
-        "sniffio": {
-            "hashes": [
-                "sha256:471b71698eac1c2112a40ce2752bb2f4a4814c22a54a3eed3676bc0f5ca9f663",
-                "sha256:c4666eecec1d3f50960c6bdf61ab7bc350648da6c126e3cf6898d8cd4ddcd3de"
-            ],
-            "index": "pypi",
-            "version": "==1.2.0"
-        },
-        "sortedcontainers": {
-            "hashes": [
-                "sha256:37257a32add0a3ee490bb170b599e93095eed89a55da91fa9f48753ea12fd73f",
-                "sha256:59cc937650cf60d677c16775597c89a960658a09cf7c1a668f86e1e4464b10a1"
-            ],
-            "version": "==2.3.0"
-        },
         "toml": {
             "hashes": [
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==0.10.2"
         },
         "traitlets": {
@@ -891,22 +840,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==5.0.5"
-        },
-        "trio": {
-            "hashes": [
-                "sha256:87a66ae61f27fe500c9024926a9ba482c07e1e0f56380b70a264d19c435ba076",
-                "sha256:a42af0634ba729cbfe8578be058750c6471dac19fbc7167ec6a3ca3f966fb424"
-            ],
-            "index": "pypi",
-            "version": "==0.18.0"
-        },
-        "trio-typing": {
-            "hashes": [
-                "sha256:35f1bec8df2150feab6c8b073b54135321722c9d9289bbffa78a9a091ea83b72",
-                "sha256:f2007df617a6c26a2294db0dd63645b5451149757e1bde4cb8dbf3e1369174fb"
-            ],
-            "index": "pypi",
-            "version": "==0.5.0"
         },
         "typed-ast": {
             "hashes": [

--- a/bot.py
+++ b/bot.py
@@ -123,9 +123,6 @@ except ValueError:
 if log_channel_id == 0:
     log_channel_id = None
 
-bot_version: str = "0.12.0"
-main_channel: Optional[discord.TextChannel] = None
-log_channel: Optional[discord.TextChannel] = None
 intents = (
     discord.Intents.default()
 )  # This basically tells the bot, for what events it should ask Discord.

--- a/bot.py
+++ b/bot.py
@@ -54,6 +54,8 @@ try:  # These are mandatory.
     import attr
     import anyio
     from anyio.abc import TaskGroup
+    from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
+    from anyio.streams.text import TextStream
 except ImportError:
     raise ImportError(
         "You have some dependencies missing, please install them with pipenv install --deploy"
@@ -136,7 +138,7 @@ intents.members = True  # This allows us to get all members of a guild. Also pri
 punctuation = string.punctuation  # A list of all punctuation characters
 
 bot: Optional[commands.Bot] = None
-bot_version: Final[str] = "1.0.0"
+bot_version: Final[str] = "2.0.0-dev"
 main_channel: Optional[discord.TextChannel] = None
 log_channel: Optional[discord.TextChannel] = None
 
@@ -2139,7 +2141,6 @@ async def cycle_playing_status_trio(period: int = 5 * 60) -> None:
 async def logging_task_anyio():
     """Sends a log message to the log channel."""
     while True:
-        # message = await aio_as_trio(logging_queue.get)()
         message = await log_recv_channel.receive()
         if not shutting_down.value:
             if log_channel is not None:
@@ -2222,7 +2223,7 @@ if __name__ == "__main__":
     ):
         with attempt:
             try:
-                trio.run(main)
+                anyio.run(main, backend="trio")
             except DiscordException as e:
                 logger.exception(e)
                 raise ValueError(

--- a/bot.py
+++ b/bot.py
@@ -50,7 +50,6 @@ try:  # These are mandatory.
     )
     from discord_slash import SlashCommand, SlashContext
     from discord_slash.utils import manage_commands
-    from async_generator import aclosing
     import attr
     import anyio
     from anyio.abc import TaskGroup
@@ -972,7 +971,8 @@ async def say3(ctx: SlashContext, *, message: str) -> None:
     if ctx.guild is not None:
         out.append(f" in the guild {ctx.guild.name}")
     if ctx.channel is not None:
-        out.append(f" in the channel {ctx.channel.name}.")
+        if isinstance(ctx.channel, discord.TextChannel):
+            out.append(f" in the channel {ctx.channel.name}.")
     logger.info("".join(out))
     await ctx.send(message, hidden=True)
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,9 +4,5 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-discord.*]
 ignore_missing_imports = True
-[mypy-trio_asyncio]
-ignore_missing_imports = True
-[mypy-trio_util]
-ignore_missing_imports = True
 
 namespace_packages = True


### PR DESCRIPTION
Anyio can give us (almost) all the benefits of trio while still using asyncio.
Channels, threads, task groups, sane exception handling, and others.
trio_asyncio is nice, but a kind of bad hack, and since we are forced to use asyncio anyway (because of Discord.py being written for asyncio), we should just drop trio and use anyio instead.
I will need to check if there is a way around the functionality that we implemented using trio_util, but I don't see any other issues.